### PR TITLE
'use strict' was removed, deleting of the unneeded variable

### DIFF
--- a/app/components/layout/c-banner.comp.js
+++ b/app/components/layout/c-banner.comp.js
@@ -1,4 +1,4 @@
-"use strict";
+
 export class CBannerComponent extends HTMLElement {
     constructor() {
         super();
@@ -14,16 +14,13 @@ export class CBannerComponent extends HTMLElement {
     }
 
     connectedCallback() {
-        var template = `
-              <div class="banner">
-                    <div class="container">
-                        <h1 class="logo-font">conduit</h1>
-                        <p>A place to share your knowledge.</p>
-                    </div>
+        this.innerHTML = `
+            <div class="banner">
+                <div class="container">
+                    <h1 class="logo-font">conduit</h1>
+                    <p>A place to share your knowledge.</p>
                 </div>
+            </div>
         `;
-        this.innerHTML = template;
     }
-
-
 }


### PR DESCRIPTION
- ES2015 module has support of `'use strict'` by default
- `var template;` is unneeded
  